### PR TITLE
Truck in some more charts

### DIFF
--- a/charts/argoproj/argo-workflows/default.nix
+++ b/charts/argoproj/argo-workflows/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "https://argoproj.github.io/argo-helm";
+  chart = "argo-workflows";
+  version = "0.39.3";
+  chartHash = "sha256-Br26UWBbmG+Pws+CWzEiva1R7WUo9tXEiPj/e9kGA00=";
+}

--- a/charts/cloudnative-pg/cloudnative-pg/default.nix
+++ b/charts/cloudnative-pg/cloudnative-pg/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "https://cloudnative-pg.github.io/charts";
+  chart = "cloudnative-pg";
+  version = "0.19.1";
+  chartHash = "sha256-hRaH+Hx0oJrMD1RNXTgWSYetp9QzSTUVRsVmUKcEeRQ=";
+}

--- a/charts/kiali/operator/default.nix
+++ b/charts/kiali/operator/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "https://kiali.org/helm-charts";
+  chart = "kiali-operator";
+  version = "1.65.0";
+  chartHash = "sha256-/ZhMoU7+hbFQyWDNgxwfiZ4G7sBxF3EYoamMFkWZLeU=";
+}

--- a/charts/kubernetes-sigs/node-feature-discovery/default.nix
+++ b/charts/kubernetes-sigs/node-feature-discovery/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "https://kubernetes-sigs.github.io/node-feature-discovery/charts/";
+  chart = "node-feature-discovery";
+  version = "0.14.3";
+  chartHash = "sha256-4/FGHLCK1Kcs9tFs0EL5cZt3NLNeswtms+ZGPs+ju2k=";
+}

--- a/charts/kyverno/kyverno/default.nix
+++ b/charts/kyverno/kyverno/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "https://kyverno.github.io/kyverno";
+  chart = "kyverno";
+  version = "3.1.0";
+  chartHash = "sha256-fu+BN/PWwIXumu/RtDZ2DyZs8r35o1ooGAFjHwDP104=";
+}

--- a/charts/longhorn/longhorn/default.nix
+++ b/charts/longhorn/longhorn/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "https://charts.longhorn.io";
+  chart = "longhorn";
+  version = "1.5.3";
+  chartHash = "sha256-IZ++Gzvjjp9EkDdFh4/eSQWm4zeJX6s7XA79krZ3dLI=";
+}

--- a/charts/metallb/metallb/default.nix
+++ b/charts/metallb/metallb/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "https://metallb.github.io/metallb/";
+  chart = "metallb";
+  version = "0.13.12";
+  chartHash = "sha256-O3xZcDzbPY77BR29teGszQ36iZvgGIxq32tnyeLGWCA=";
+}


### PR DESCRIPTION
Ones I happen to use that I figure many others will too.

Dirnames not set in stone: feel free to suggest changes and I'll `git commit --fixup` them.

The ones I left out:

- aoe/sidecar-cleaner (useful for `Job`s under Istio)
- intel/device-plugins-gpu
- intel/device-plugins-operator
- kubernetes/dashboard
- kubernetes-csi/driver-nfs
- kubernetes-sigs/nfs-subdir
