### PR TITLE
use mkPoetryEnv from out-of-tree poetry2nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,7 @@
   } // flake-utils.lib.eachDefaultSystem (system:
     let
       pkgs = nixpkgs.legacyPackages.${system};
-      inherit (poetry2nix.lib.mkPoetry2Nix { inherit pkgs; }) mkPoetryApplication;
+      inherit (poetry2nix.lib.mkPoetry2Nix { inherit pkgs; }) mkPoetryEnv mkPoetryApplication;
     in
     {
       chartsDerivations = self.charts { inherit pkgs; };
@@ -58,7 +58,7 @@
           nixpkgs-fmt
           poetry
           python310Packages.autopep8
-          (pkgs.poetry2nix.mkPoetryEnv {
+          (mkPoetryEnv {
             python = pkgs.python310;
             projectDir = ./.;
             editablePackageSources = {


### PR DESCRIPTION
Fixes `nix develop` which was throwing an error since we were still using mkPoetryEnv from nixpkgs:

```
error:
       … while calling the 'derivationStrict' builtin

         at //builtin/derivation.nix:9:12: (source not available)

       … while evaluating derivation 'nix-shell'
         whose name attribute is located at /nix/store/4fgs7yzsy2dqnjw8j42qlp9i1vgarzy0-source/pkgs/stdenv/generic/make-derivation.nix:348:7

       … while evaluating attribute 'buildInputs' of derivation 'nix-shell'

         at /nix/store/4fgs7yzsy2dqnjw8j42qlp9i1vgarzy0-source/pkgs/stdenv/generic/make-derivation.nix:395:7:

          394|       depsHostHost                = elemAt (elemAt dependencies 1) 0;
          395|       buildInputs                 = elemAt (elemAt dependencies 1) 1;
             |       ^
          396|       depsTargetTarget            = elemAt (elemAt dependencies 2) 0;

       error: poetry2nix is now maintained out-of-tree. Please use https://github.com/nix-community/poetry2nix/
```