### PR TITLE
rook-release/rook-ceph: init at 1.13.4

### DIFF
--- a/charts/isindir/sops-secrets-operator/default.nix
+++ b/charts/isindir/sops-secrets-operator/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "https://isindir.github.io/sops-secrets-operator/";
+  chart = "sops-secrets-operator";
+  version = "0.18.3";
+  chartHash = "sha256-9lSOqBOAvgBEuNlQG2ffnG/6EkwPJKoeIBOoDWjsTQc=";
+}

--- a/charts/rook-release/rook-ceph-cluster/default.nix
+++ b/charts/rook-release/rook-ceph-cluster/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "https://charts.rook.io/release";
+  chart = "rook-ceph-cluster";
+  version = "1.13.4";
+  chartHash = "sha256-Hnpp9dE1eHl841Wef6Jfx1Zm2X58yUL5OvhLPg2h7Zk=";
+}

--- a/charts/rook-release/rook-ceph/default.nix
+++ b/charts/rook-release/rook-ceph/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "https://charts.rook.io/release";
+  chart = "rook-ceph";
+  version = "1.13.4";
+  chartHash = "sha256-kSLZ22AKeVfgHpaO7yilNip2WVnsgcv1Ec+j940uubM=";
+}


### PR DESCRIPTION
rook-release/rook-ceph: init at 1.13.4
rook-release/rook-ceph-cluster: init at 1.13.4

note that `helmupdater` cannot deal with these charts: 
```
$ nix run .#helmupdater -- init "https://charts.rook.io/release" rook-release/rook-ceph
Traceback (most recent call last):

  File "/nix/store/x8adj0i6gm3vxk22pc30n4hylynscj9b-python3.10-helmupdater-0.1.0/bin/.helmupdater-wrapped", line 9, in <module>
    sys.exit(app())

  File "/nix/store/x8adj0i6gm3vxk22pc30n4hylynscj9b-python3.10-helmupdater-0.1.0/lib/python3.10/site-packages/helmupdater/__init__.py", line 198, in init
    update_one_chart(repo_name, chart_name, local_chart, commit=False, fail_on_fetch=True)

  File "/nix/store/x8adj0i6gm3vxk22pc30n4hylynscj9b-python3.10-helmupdater-0.1.0/lib/python3.10/site-packages/helmupdater/__init__.py", line 92, in update_one_chart
    version = VersionInfo.parse(version_str)

  File "/nix/store/lphr10lgh2cwfmfwhkn9s0mq5r7ayp19-python3.10-semver-2.13.0/lib/python3.10/site-packages/semver.py", line 726, in parse
    raise ValueError("%s is not valid SemVer string" % version)

ValueError: 0 is not valid SemVer string
```