### PR TITLE
bitnami/external-dns: init at 7.2.0

### DIFF
--- a/charts/bitnami/external-dns/default.nix
+++ b/charts/bitnami/external-dns/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "https://charts.bitnami.com/bitnami/";
+  chart = "external-dns";
+  version = "7.2.0";
+  chartHash = "sha256-TDDLqss99R4jEj4bDf5z4UDAH20oTViR9MzuuuxAYl8=";
+}


### PR DESCRIPTION
This PR adds the bitnami packaged helm chart for external-dns 7.2.0, in favor of those who use the bitnami version.