### PR TITLE
traefik/traefik: fix chartHash

### DIFF
--- a/charts/traefik/traefik/default.nix
+++ b/charts/traefik/traefik/default.nix
@@ -2,5 +2,5 @@
   repo = "https://traefik.github.io/charts/";
   chart = "traefik";
   version = "34.3.0";
-  chartHash = "sha256-YRfWJn2qnBnskPyN2x2pqJ9g5BPy3X9neKufRGX4YuY=";
+  chartHash = "sha256-BGIHnYZ15bzEX9nJ4uxh8egxAHewqJ//IoAXJ5ln6tk=";
 }


### PR DESCRIPTION
It seems that the helm chart version has been updated in-place as the current chartHash is wrong.