### PR TITLE
kubernetes-sigs/metrics-server: init at 3.13.0

### DIFF
--- a/charts/kubernetes-sigs/metrics-server/default.nix
+++ b/charts/kubernetes-sigs/metrics-server/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "https://kubernetes-sigs.github.io/metrics-server/";
+  chart = "metrics-server";
+  version = "3.13.0";
+  chartHash = "sha256-Q2BMifK73yPRs/S6w9yY5ZuRs0I3hzSRi9R12Li6ZRI=";
+}


### PR DESCRIPTION
Add metrics-server.

Have had it laying locally for a couple of weeks, so might not be latest version, but I assume the nightly run will update it, if any new releases have been made available.