### PR TITLE
qdrant/qdrant: init at 1.18.2

### DIFF
--- a/charts/qdrant/qdrant/default.nix
+++ b/charts/qdrant/qdrant/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "https://qdrant.github.io/qdrant-helm";
+  chart = "qdrant";
+  version = "1.18.2";
+  chartHash = "sha256-bG77k6AkKJuwOFPoWQg4AEE/KmPoaunrOuPTseEMKD8=";
+}


### PR DESCRIPTION
Adds the [Qdrant](https://qdrant.tech) Helm chart from the official repository (`https://qdrant.github.io/qdrant-helm`).

Generated via:

```sh
nix run .#helmupdater -- init "https://qdrant.github.io/qdrant-helm" qdrant/qdrant --commit
```

Verified the chart builds locally:

```sh
nix build .#chartsDerivations.x86_64-linux.qdrant.qdrant
```