### PR TITLE
grafana/grafana-operator: init at 5.24.0

### DIFF
--- a/charts/grafana/grafana-operator/default.nix
+++ b/charts/grafana/grafana-operator/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "https://grafana.github.io/helm-charts/";
+  chart = "grafana-operator";
+  version = "5.24.0";
+  chartHash = "sha256-jULnmFaxi3gsWbCnE26FfML6MOqQ60QCpMuOoSv0hdw=";
+}


### PR DESCRIPTION
Adds the [Grafana Operator](https://github.com/grafana/grafana-operator) Helm chart from the official Grafana repository (`https://grafana.github.io/helm-charts/`).

Generated via:

```sh
nix run .#helmupdater -- init "https://grafana.github.io/helm-charts/" grafana/grafana-operator --commit
```

Verified the chart builds locally:

```sh
nix build .#chartsDerivations.x86_64-linux.grafana.grafana-operator
```