### PR TITLE
grafana/mimir-distributed: init at 6.0.6

### DIFF
--- a/charts/grafana/mimir-distributed/default.nix
+++ b/charts/grafana/mimir-distributed/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "https://grafana.github.io/helm-charts/";
+  chart = "mimir-distributed";
+  version = "6.0.6";
+  chartHash = "sha256-oUDkZadcXKK3xlwt0US0krtQPjmBkchHZThJiW0MLHw=";
+}


### PR DESCRIPTION
Adds the [Grafana Mimir](https://github.com/grafana/mimir) (`mimir-distributed`) Helm chart from the official Grafana repository (`https://grafana.github.io/helm-charts/`).

Generated via:

```sh
nix run .#helmupdater -- init "https://grafana.github.io/helm-charts/" grafana/mimir-distributed --commit
```

Verified the chart builds locally:

```sh
nix build .#chartsDerivations.x86_64-linux.grafana.mimir-distributed
```