### PR TITLE
aws/aws-load-balancer-controller: init at 3.4.0

### DIFF
--- a/charts/aws/aws-load-balancer-controller/default.nix
+++ b/charts/aws/aws-load-balancer-controller/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "https://aws.github.io/eks-charts";
+  chart = "aws-load-balancer-controller";
+  version = "3.4.0";
+  chartHash = "sha256-buV3J7h/J4gKWwFfolE8zbe8eMLWpbPigcR2USc8gAQ=";
+}


### PR DESCRIPTION
Adds the [AWS Load Balancer Controller](https://github.com/kubernetes-sigs/aws-load-balancer-controller) Helm chart from the AWS-maintained EKS charts repository (`https://aws.github.io/eks-charts`).

Placed under `aws/` to match the chart's hosting source (the `eks` Helm repo is published by AWS), consistent with nixhelm's hosting-based repo naming.

Generated via:

```sh
nix run .#helmupdater -- init "https://aws.github.io/eks-charts" aws/aws-load-balancer-controller --commit
```

Verified the chart builds locally:

```sh
nix build .#chartsDerivations.x86_64-linux.aws.aws-load-balancer-controller
```