### PR TITLE
smallstep/step-issuer: init at 1.10.2

### DIFF
--- a/charts/smallstep/step-issuer/default.nix
+++ b/charts/smallstep/step-issuer/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "https://smallstep.github.io/helm-charts";
+  chart = "step-issuer";
+  version = "1.10.2";
+  chartHash = "sha256-uqyeFW26FxI5yFhd+al2UT/hcp5y5Tj1QdHVR43/ILc=";
+}


### PR DESCRIPTION
Adds the [step-issuer](https://github.com/smallstep/step-issuer) Helm chart (a cert-manager issuer backed by Smallstep CA) from the official Smallstep repository (`https://smallstep.github.io/helm-charts`).

Generated via:

```sh
nix run .#helmupdater -- init "https://smallstep.github.io/helm-charts" smallstep/step-issuer --commit
```

Verified the chart builds locally:

```sh
nix build .#chartsDerivations.x86_64-linux.smallstep.step-issuer
```