### PR TITLE
cloudflare/origin-ca-issuer: init at 0.6.9

### DIFF
--- a/charts/cloudflare/origin-ca-issuer/default.nix
+++ b/charts/cloudflare/origin-ca-issuer/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "oci://ghcr.io/cloudflare/origin-ca-issuer-charts";
+  chart = "origin-ca-issuer";
+  version = "0.6.9";
+  chartHash = "sha256-RwNZHbgB+Cwz22CDv5Vzneh4mzKL0HMqQsIqffa/52k=";
+}


### PR DESCRIPTION
Adds the [origin-ca-issuer](https://github.com/cloudflare/origin-ca-issuer) Helm chart (a cert-manager issuer for Cloudflare Origin CA) from Cloudflare's official OCI registry (`oci://ghcr.io/cloudflare/origin-ca-issuer-charts`).

The chart is distributed as an OCI artifact; the legacy HTTP repo is deprecated in favor of GHCR.

Generated via:

```sh
nix run .#helmupdater -- init "oci://ghcr.io/cloudflare/origin-ca-issuer-charts" cloudflare/origin-ca-issuer --commit
```

Verified the chart builds locally:

```sh
nix build .#chartsDerivations.x86_64-linux.cloudflare.origin-ca-issuer
```