### PR TITLE
dragonflydb/dragonfly-operator: init at v1.6.1

### DIFF
--- a/charts/dragonflydb/dragonfly-operator/default.nix
+++ b/charts/dragonflydb/dragonfly-operator/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "oci://ghcr.io/dragonflydb/dragonfly-operator/helm";
+  chart = "dragonfly-operator";
+  version = "v1.6.1";
+  chartHash = "sha256-D4UoKJSzYA+hQ3oTshtFhYv15Mt9s+phXb+bjx6/LW8=";
+}


### PR DESCRIPTION
Adds the [Dragonfly Operator](https://github.com/dragonflydb/dragonfly-operator) Helm chart (a Kubernetes operator to deploy and manage Dragonfly in-memory datastore instances) from DragonflyDB's official OCI registry (`oci://ghcr.io/dragonflydb/dragonfly-operator/helm`).

The chart is distributed only as an OCI artifact on GHCR.

Generated via:

```sh
nix run .#helmupdater -- init "oci://ghcr.io/dragonflydb/dragonfly-operator/helm" dragonflydb/dragonfly-operator --commit
```

Verified the chart builds locally:

```sh
nix build .#chartsDerivations.x86_64-linux.dragonflydb.dragonfly-operator
```