### PR TITLE
M0NsTeRRR/routinator: init at 2.3.1

### DIFF
--- a/charts/M0NsTeRRR/routinator/default.nix
+++ b/charts/M0NsTeRRR/routinator/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "oci://ghcr.io/m0nsterrr/helm-charts";
+  chart = "routinator";
+  version = "2.3.1";
+  chartHash = "sha256-Y1RId6feFmEPdFPXyiApN+RvjWAivUACULgbt//VlOA=";
+}


### PR DESCRIPTION
Adding Routinator 3000: a free, open-source RPKI Relying Party software.

* Routinator: https://github.com/NLnetLabs/routinator
* Helm chart: https://artifacthub.io/packages/helm/m0nsterrr-routinator/routinator