### PR TITLE
Adding paperclipinc/openclaw-operator

### DIFF
--- a/charts/openclaw-rocks/openclaw-operator/default.nix
+++ b/charts/openclaw-rocks/openclaw-operator/default.nix
@@ -1,6 +1,0 @@
-{
-  repo = "oci://ghcr.io/openclaw-rocks/charts";
-  chart = "openclaw-operator";
-  version = "0.34.4";
-  chartHash = "sha256-krAhNKedD01qNq7hLKJOeSwTtQIxQ0tVmtoV+Aknubs=";
-}

--- a/charts/paperclipinc/openclaw-operator/default.nix
+++ b/charts/paperclipinc/openclaw-operator/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "oci://ghcr.io/paperclipinc/charts";
+  chart = "openclaw-operator";
+  version = "0.36.5";
+  chartHash = "sha256-YSwhgVIwO4P0PvkToophDItiTi8rdjTCPMPC5+ejSWM=";
+}


### PR DESCRIPTION
This replaces former `openclaw-rocks/openclaw-operator`.

Since nixhelm doesn't have a rename mechanism yet, I'm deleting the old one.

Tagging @sedlund (original contributor). Sorry for inconvenience!