### PR TITLE
Bump helmupdater version after dependencies update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2026-07-20
+
+### General
+
+- Updated flake inputs.
+
+### helmupdater 0.2.7
+
+#### Changed
+
+- Updated dependencies.
+
+#### Fixed
+
+- Fixed failing test for `git.add_and_commit`.
+
 ## 2026-02-09
 
 ### helmupdater 0.2.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "helmupdater"
-version = "0.2.6"
+version = "0.2.7"
 description = ""
 authors = [{ name = "Vladimir Pouzanov", email = "farcaller@gmail.com" }]
 maintainers = [{ name = "Damon River", email = "damonriver@fastmail.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -132,7 +132,7 @@ wheels = [
 
 [[package]]
 name = "helmupdater"
-version = "0.2.6"
+version = "0.2.7"
 source = { editable = "." }
 dependencies = [
     { name = "chevron" },


### PR DESCRIPTION
This is a quick followup for https://github.com/nix-community/nixhelm/pull/118. I always keep forgetting to bump version after making changes to the project.