### PR TITLE
traefik/traefik-crds: init at 1.18.0

### DIFF
--- a/charts/traefik/traefik-crds/default.nix
+++ b/charts/traefik/traefik-crds/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "https://traefik.github.io/charts/";
+  chart = "traefik-crds";
+  version = "1.18.0";
+  chartHash = "sha256-aXq6V5bZ+cuXHWNHNLTeqXMtxCf5oyS0DTMXfscPk7w=";
+}


### PR DESCRIPTION
Add traefik-crds chart package.