### PR TITLE
Improve tags filtering in OCI repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2026-08-11
+
+### helmupdater 0.2.9
+
+#### Changed
+
+- Filter dummy tags in OCI repositories [#123](https://github.com/nix-community/nixhelm/issues/123).
+
 ## 2026-07-21
 
 ### General

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "helmupdater"
-version = "0.2.8"
+version = "0.2.9"
 description = ""
 authors = [{ name = "Vladimir Pouzanov", email = "farcaller@gmail.com" }]
 maintainers = [{ name = "Damon River", email = "damonriver@fastmail.com" }]

--- a/src/helmupdater/registry/oci.py
+++ b/src/helmupdater/registry/oci.py
@@ -8,6 +8,9 @@ from oras.client import OrasClient
 
 from helmupdater.chart.chart_version import ChartVersion, parse_versions
 
+# Require version to have a minimal number of components. Following semver.
+MIN_VERSION_COMPONENTS = 3
+
 
 @contextmanager
 def _timeout(seconds: int = 5):
@@ -107,7 +110,11 @@ class OCIRegistry:
             repo_name=self.name,
             chart_name=chart_name,
         )
-        return [v for v in versions if v.is_stable]
+        return [
+            v
+            for v in versions
+            if v.is_stable and len(v.version_info.release) >= MIN_VERSION_COMPONENTS
+        ]
 
     @property
     def registry_type(self) -> str:

--- a/tests/registry/test_oci.py
+++ b/tests/registry/test_oci.py
@@ -71,3 +71,27 @@ class TestOCIRegistry:
         assert len(versions) == 2
         version_strings = [v.version for v in versions]
         assert version_strings == ["1.0.0", "2.0.0"]
+
+    @patch.object(OCIRegistry, "_fetch_raw_versions")
+    def test_get_versions_filters_bad_tags(self, mock_fetch_raw_versions):
+        """Test that get_versions excludes bad tags."""
+        registry = OCIRegistry("oci://example.com/charts", "test")
+
+        mixed_versions = [
+            # bad tags
+            "v0-eff4321d9b52b38eb0be8061fe76adf5cf20a185",
+            "sha256-199866c04a14b6769c9d98fe9647a861cd49f296b35b8dcc585650e0d4d27f04.sig",
+            "20221129",
+            "20221003",
+            "2.0",
+            # valid tags
+            "1.11.1",
+            "1.0.10",
+            "v0.34.7",
+        ]
+        mock_fetch_raw_versions.return_value = mixed_versions
+        versions = registry.get_versions("testchart")
+
+        version_strings = {v.version for v in versions}
+        assert version_strings == {"1.11.1", "1.0.10", "v0.34.7"}
+        assert max(versions).version == "1.11.1"

--- a/uv.lock
+++ b/uv.lock
@@ -132,7 +132,7 @@ wheels = [
 
 [[package]]
 name = "helmupdater"
-version = "0.2.8"
+version = "0.2.9"
 source = { editable = "." }
 dependencies = [
     { name = "chevron" },


### PR DESCRIPTION
While reading tags in OCI repo, add an extra filter to tags: check if tag has at least 3 components. Python's `packaging.version` is quite permissive, and this allows invalid tags to jump to the top of the list.

This addresses https://github.com/nix-community/nixhelm/issues/123. Thanks @typedrat for pointing this out!

Checking `mediaType` of the manifest is also a good option. Will circle back to it if project encounters any more non-compliant repos.